### PR TITLE
fix: add isLogin property to the sessionStorage checking login status before fetch data

### DIFF
--- a/src/components/Profile/PersonalInfo.tsx
+++ b/src/components/Profile/PersonalInfo.tsx
@@ -12,6 +12,11 @@ export default function PersonalInfo() {
 
   useEffect(() => {
     const fetchUserInfo = async () => {
+      const isLogin = sessionStorage.getItem('isLogin');
+      if (!(isLogin && isLogin.length)) {
+        return;
+      }
+
       try {
         const userId = sessionStorage.getItem('id');
         if (!userId) {

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -20,6 +20,11 @@ function Calendar() {
   const [isAddEventModalOpen, setIsAddEventModalOpen] = useState(false);
 
   useEffect(() => {
+    const isLogin = sessionStorage.getItem('isLogin');
+    if (!(isLogin && isLogin.length)) {
+      return;
+    }
+
     if (eventStatus === 'idle') {
       dispatch(fetchEvents());
     }

--- a/src/pages/Correction.tsx
+++ b/src/pages/Correction.tsx
@@ -28,6 +28,11 @@ function Correction() {
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
+    const isLogin = sessionStorage.getItem('isLogin');
+    if (!(isLogin && isLogin.length)) {
+      return;
+    }
+
     if (!isFetched) {
       setIsLoading(true);
       dispatch(initializeCorrectionAsync()).then(() => {

--- a/src/pages/Salary.tsx
+++ b/src/pages/Salary.tsx
@@ -21,6 +21,11 @@ function Salary() {
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
+    const isLogin = sessionStorage.getItem('isLogin');
+    if (!(isLogin && isLogin.length)) {
+      return;
+    }
+
     if (!isFetched) {
       setIsLoading(true);
       dispatch(initializeSalaryAsync()).then(() => {

--- a/src/store/login.ts
+++ b/src/store/login.ts
@@ -7,6 +7,7 @@ interface UserState {
   email: string | null;
   joiningDate: string | null;
   name: string | null;
+  isLogin: string | null;
 }
 
 const initialState: UserState = {
@@ -16,6 +17,7 @@ const initialState: UserState = {
   email: '없음',
   joiningDate: '없음',
   name: '없음',
+  isLogin: sessionStorage.getItem('isLogin'),
 };
 
 const userSlice = createSlice({
@@ -39,6 +41,7 @@ const userSlice = createSlice({
       state.email = action.payload.email;
       state.joiningDate = action.payload.joiningDate;
       state.name = action.payload.name;
+      sessionStorage.setItem('isLogin', 'true');
     },
     clearUserInfo: (state) => {
       state.department = null;
@@ -47,6 +50,7 @@ const userSlice = createSlice({
       state.email = null;
       state.joiningDate = null;
       state.name = null;
+      sessionStorage.setItem('isLogin', '');
     },
   },
 });


### PR DESCRIPTION
사이트에 처음 접속할 때, 또는 로그인 상태가 아닐 때 각 페이지에 접근하려고 하면 useCheckLogin 훅이 발동되어 /login으로 리다이렉트 됩니다.
하지만 각 페이지의 useEffect 훅 안에서 세션 스토리지에 userId 값이 없으면 에러를 내뱉게 됩니다.
그래서 현재 라이브 버전에서는 정상적인 작동임에도 불구하고 처음 사이트에 들어가면 페이지의 useEffect 훅이 발동되어 콘솔창에 에러가 뜨고 있습니다.
그래서 세션 스토리지에 isLogin이라는 속성을 추가해서 각 페이지에서 페칭하기 전에 isLogin으로 한번 검사하도록 처리했습니다.